### PR TITLE
Fix minor changes

### DIFF
--- a/src/Verification/ErrorScene/index.tsx
+++ b/src/Verification/ErrorScene/index.tsx
@@ -12,7 +12,7 @@ import { VerificationError } from 'Verification/types'
 const texts = {
   [VerificationError.AlreadyVerified]: {
     heading: 'Looks like you have already verified for this server.',
-    description: 'You can only verify once for each server.',
+    description: 'You have already verified with this server and the server only supports one verification per user.',
   },
 
   [VerificationError.Unknown]: {

--- a/src/Verification/InitialScene/index.tsx
+++ b/src/Verification/InitialScene/index.tsx
@@ -36,19 +36,23 @@ export const InitialScene = memo(function Initial(props: {
         <div className="grid gap-y-6">
           <div className="font-bold text-12 uppercase tracking-[0.2em]">How to verify?</div>
 
-          <CredentialsItem
-            icon="mobile-device-huge"
-            heading="Phone number"
-            description="A single-use code will be delivered to you via SMS"
-            roles={props.roles?.phone || []}
-          />
+          {props.credentials.includes('phone') && (
+            <CredentialsItem
+              icon="mobile-device-huge"
+              heading="Phone number"
+              description="A single-use code will be delivered to you via SMS"
+              roles={props.roles?.phone || []}
+            />
+          )}
 
-          <CredentialsItem
-            icon="orb-huge"
-            heading="The Orb"
-            description="Completely private iris imaging with a device called an orb"
-            roles={props.roles?.orb || []}
-          />
+          {props.credentials.includes('orb') && (
+            <CredentialsItem
+              icon="orb-huge"
+              heading="The Orb"
+              description="Completely private iris imaging with a device called an orb"
+              roles={props.roles?.orb || []}
+            />
+          )}
         </div>
 
         {props.actionId && props.signal && (

--- a/src/Verification/index.tsx
+++ b/src/Verification/index.tsx
@@ -106,7 +106,7 @@ export const Verification = memo(function Verification(props: {
       </Modal>
 
       <InfoLine
-        className="fixed bottom-0 inset-x-0 z-10"
+        className="fixed bottom-0 inset-x-0 z-50"
         text="The Discord Bouncer helps prevent spam and increase the quality of the community by making sure everyone who joins is a human. "
       />
     </Layout>


### PR DESCRIPTION
> When the proof verification is happening there’s an overlay in the modal, but the overlay does not cover the entire modal, it looks cut off

fixed

> If you only have one credential enabled for your server, we still tell you you can verify with these two, I think there’s a missing check on whether the cred is enabled

fixed

![image](https://user-images.githubusercontent.com/104859710/219424930-7c908451-fba6-4924-a004-c33e3c2502a1.png)
![image](https://user-images.githubusercontent.com/104859710/219425040-33dc4e65-35c4-4a64-a040-491e14d26d08.png)

> In the error message when the error is because the user has already been verified, we still say “Feel free to restart the validation with /verify command. This user has already been verified”, we should change to “You have already verified with this server and the server only supports one verification per user.”

![image](https://user-images.githubusercontent.com/104859710/219427678-f0b17470-835d-4277-8145-0e4bbe36a4bb.png)
![image](https://user-images.githubusercontent.com/104859710/219427847-19dd8c20-554b-4fa8-9fa2-0ae95491c07e.png)

![image](https://user-images.githubusercontent.com/104859710/219428119-01ea0075-f944-4243-91cf-fed6488dfefc.png)
![image](https://user-images.githubusercontent.com/104859710/219428174-7666239e-da3c-4793-a4ee-179665f97442.png)
