### PR TITLE
feat: remove roles from previous account of same user

### DIFF
--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -67,6 +67,10 @@ export const assignGuildMemberRole = async (guildId: string, memberId: string, r
   return await rest.put(Routes.guildMemberRole(guildId, memberId, roleId))
 }
 
+export const removeGuildMemberRole = async (guildId: string, memberId: string, roleId: string) => {
+  return await rest.delete(Routes.guildMemberRole(guildId, memberId, roleId))
+}
+
 export const editInteractionMessage = async (interactionToken: string, embeds: APIEmbed[]) => {
   const body: RESTPostAPIChannelMessageJSONBody = {
     embeds,

--- a/src/services/dynamodb.ts
+++ b/src/services/dynamodb.ts
@@ -166,7 +166,11 @@ export const saveBotConfig = async (botConfig: BotConfig): Promise<PutDataResult
   return result
 }
 
-export const getNullifierHash = async ({ guild_id, nullifier_hash, credential_type, user_id }: NullifierHashData) => {
+export const getNullifierHash = async ({
+  guild_id,
+  nullifier_hash,
+  credential_type,
+}: Omit<NullifierHashData, 'user_id'>) => {
   let result: GetItemResult<NullifierHashData>
 
   try {
@@ -178,18 +182,16 @@ export const getNullifierHash = async ({ guild_id, nullifier_hash, credential_ty
           '#guild_id': 'guild_id',
           '#nullifier_hash': 'nullifier_hash',
           '#signal_type': 'signal_type',
-          '#user_id': 'user_id',
         },
 
         ExpressionAttributeValues: {
           ':guild_id': { S: guild_id },
           ':nullifier_hash': { S: nullifier_hash },
           ':signal_type': { S: credential_type },
-          ':user_id': { S: user_id },
         },
 
         KeyConditionExpression: '#guild_id = :guild_id AND #nullifier_hash = :nullifier_hash',
-        FilterExpression: '#signal_type = :signal_type AND #user_id = :user_id',
+        FilterExpression: '#signal_type = :signal_type',
       }),
     )
 


### PR DESCRIPTION
Related to [this](https://ottofeller.slack.com/archives/C03MN2BP61J/p1678377689895969) Slack message. 

Tested locally with two accounts using the simulator:
- First account verifies
- Raw adds to the dynamoDB
- First account receives roles
- Second account of the same user start verification
- Checking DynamoDB 
- If `nullifier_hash` from the idkit result exists in DynamoDB and we received the not same user id that exists in the DynamoDB row with this `nullifier_hash` => removing roles from 1st discord account.
  - If the user is the same then just throw that user already verified.
- Adding roles to the second account.

- If there is no such nullifier_hash in DB, just create a row and set roles.